### PR TITLE
Release/0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.0.2
 - Changes supporting CloudHarvestCoreTasks 0.6.2
 - the `available_templates` information is now included in the heartbeat
+- added `agent/list_plugins` and `agent/install_plugins` endpoints
 
 # 0.0.1
 - Initial implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.0.2
-- Changes supporting CloudHarvestCoreTasks 0.6.0
+- Changes supporting CloudHarvestCoreTasks 0.6.2
 
 # 0.0.1
 - Initial implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.0.2
 - Changes supporting CloudHarvestCoreTasks 0.6.2
+- the `available_templates` information is now included in the heartbeat
 
 # 0.0.1
 - Initial implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Changes supporting CloudHarvestCoreTasks 0.6.2
 - the `available_templates` information is now included in the heartbeat
 - added `agent/list_plugins` and `agent/install_plugins` endpoints
+- replaced `pstar` with `accounts` key in heartbeat
 
 # 0.0.1
 - Initial implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # 0.0.2
-- Changes supporting CloudHarvestCoreTasks 0.6.2
-- the `available_templates` information is now included in the heartbeat
-- added `agent/list_plugins` and `agent/install_plugins` endpoints
-- replaced `pstar` with `accounts` key in heartbeat
+- Changes supporting CloudHarvestCoreTasks 0.6.3
+- The `available_templates` information is now included in the heartbeat
+- Added `agent/list_plugins` and `agent/install_plugins` endpoints
+- Replaced `pstar` with `accounts` key in heartbeat
+- Added `harvest.templates` report
+- Updated some templates
 
 # 0.0.1
 - Initial implementation

--- a/CloudHarvestAgent/__main__.py
+++ b/CloudHarvestAgent/__main__.py
@@ -15,6 +15,11 @@ def main(**kwargs):
     from flask import Flask
     CloudHarvestNode.flask = Flask('CloudHarvestAgent')
 
+    # Install plugins
+    from CloudHarvestCorePluginManager.plugins import generate_plugins_file, install_plugins
+    generate_plugins_file(plugins=CloudHarvestNode.config.get('plugins') or [])
+    install_plugins()
+
     # Find all plugins and register their objects and templates
     from CloudHarvestCorePluginManager import register_all
     register_all()
@@ -23,11 +28,11 @@ def main(**kwargs):
     from CloudHarvestCorePluginManager.registry import Registry
     with CloudHarvestNode.flask.app_context():
         [
-            CloudHarvestNode.flask.register_blueprint(api_blueprint)
-            for api_blueprint in Registry.find(result_key='instances',
-                                               name='harvest_blueprint',
-                                               category='harvest_agent_blueprint')
-            if api_blueprint is not None
+            CloudHarvestNode.flask.register_blueprint(blueprint)
+            for blueprint in Registry.find(result_key='instances',
+                                           category='blueprint',
+                                           name='agent')
+            if blueprint is not None
         ]
 
     CloudHarvestNode.run(**kwargs)

--- a/CloudHarvestAgent/app.py
+++ b/CloudHarvestAgent/app.py
@@ -63,6 +63,8 @@ class CloudHarvestNode:
 
         ssl_context = (flat_kwargs['agent.connection.pem'], ) if flat_kwargs.get('agent.connection.pem') else ()
 
+        logger.debug(CloudHarvestNode.flask.url_map)
+
         # Start the Flask application
         CloudHarvestNode.flask.run(host=flat_kwargs.get('agent.connection.host', 'localhost'),
                                    port=flat_kwargs.get('agent.connection.port', 8000),

--- a/CloudHarvestAgent/app.py
+++ b/CloudHarvestAgent/app.py
@@ -171,6 +171,11 @@ def start_node_heartbeat(expiration_multiplier: int = 5, heartbeat_check_rate: f
         node_role = CloudHarvestNode.ROLE
 
         node_info = {
+            "accounts": sorted([
+                f'{p}:{account}'
+                for p in CloudHarvestNode.config.get('platforms', {}).keys() or []
+                for account in CloudHarvestNode.config['platforms'][p].get('accounts') or []
+            ]),
             "architecture": f'{platform.machine()}',
             "available_chains": sorted(Registry.find(category='chain', result_key='name', limit=None)),
             "available_tasks": sorted(Registry.find(category='task', result_key='name', limit=None)),
@@ -192,11 +197,6 @@ def start_node_heartbeat(expiration_multiplier: int = 5, heartbeat_check_rate: f
             "status": CloudHarvestNode.job_queue.detailed_status(),
             "version": app_metadata.get('version')
         }
-
-        node_info.update({
-            f'pstar_{k}': v
-            for k, v in CloudHarvestNode.config.get('agent', {}).get('pstar', {}).items()
-        })
 
         while True:
             # Update the last heartbeat time

--- a/CloudHarvestAgent/app.py
+++ b/CloudHarvestAgent/app.py
@@ -172,6 +172,11 @@ def start_node_heartbeat(expiration_multiplier: int = 5, heartbeat_check_rate: f
             "architecture": f'{platform.machine()}',
             "available_chains": sorted(Registry.find(category='chain', result_key='name', limit=None)),
             "available_tasks": sorted(Registry.find(category='task', result_key='name', limit=None)),
+            "available_templates": sorted([
+                f'{result["category"]}/{result["name"]}'
+                for result in
+                Registry.find(category='template_*', result_key='*', limit=None)
+            ]),
             "ip": gethostbyname(getfqdn()),
             "heartbeat_seconds": heartbeat_check_rate,
             "name": node_name,
@@ -187,7 +192,7 @@ def start_node_heartbeat(expiration_multiplier: int = 5, heartbeat_check_rate: f
         }
 
         node_info.update({
-            f'pstar.{k}': v
+            f'pstar_{k}': v
             for k, v in CloudHarvestNode.config.get('agent', {}).get('pstar', {}).items()
         })
 

--- a/CloudHarvestAgent/blueprints/agent.py
+++ b/CloudHarvestAgent/blueprints/agent.py
@@ -1,7 +1,6 @@
 """
 The agent blueprint is responsible for managing the Flask agent.s
 """
-
 from CloudHarvestCoreTasks.blueprints import HarvestAgentBlueprint
 from flask import Response, jsonify, request
 from logging import getLogger
@@ -24,6 +23,84 @@ def reload() -> Response:
 
     return not_implemented_error()
 
+
+@agent_blueprint.route(rule='install_plugin', methods=['GET'])
+def install_plugin() -> Response:
+    """
+    Installs a plugin from the plugins.txt file.
+
+    Arguments
+    url_or_package_name (str) - the URL or package name of the plugin to install.
+    branch (str, optional) - the branch of the plugin to install. Defaults to 'main'.
+    """
+
+    from CloudHarvestCorePluginManager.plugins import generate_plugins_file, install_plugins, read_plugins_file
+
+    message = 'OK'
+    result = []
+
+    try:
+        from CloudHarvestAgent.blueprints.base import safe_request_get_json
+        request_json = safe_request_get_json(request)
+
+        url_or_package_name = request_json.get('url_or_package_name')
+        branch = request_json.get('branch') or 'main'
+
+        if not url_or_package_name:
+            raise ValueError('`url_or_package_name` is required')
+
+        plugins = read_plugins_file() or []
+
+        plugins.append(
+            {
+                'url_or_package_name': url_or_package_name,
+                'branch': branch
+            }
+        )
+
+        # Generate the plugins file
+        generate_plugins_file(plugins=plugins)
+
+        # Install the plugins
+        install_plugins()
+
+        # Reread the plugins file
+        result = read_plugins_file() or []
+
+    except Exception as ex:
+        message = f'Failed to install plugin: {str(ex)}'
+
+    finally:
+        return jsonify({
+            'success': True if message == 'OK' else False,
+            'message': message,
+            'result': result
+        })
+
+
+@agent_blueprint.route(rule='/list_plugins', methods=['GET'])
+def list_plugins() -> Response:
+    """
+    Lists the plugins which should be installed by the agent.
+    """
+
+    from CloudHarvestCorePluginManager.plugins import read_plugins_file
+
+    message = 'OK'
+    result = []
+
+    try:
+        result = read_plugins_file() or []
+
+    except Exception as ex:
+        message = f'Failed to read plugins file: {str(ex)}'
+
+    finally:
+        return jsonify({
+            'success': True if message == 'OK' else False,
+            'message': 'OK',
+            'result': result
+        })
 
 # @agent_blueprint.route(rule='shutdown', methods=['GET'])
 # def shutdown() -> Response:

--- a/CloudHarvestAgent/jobs.py
+++ b/CloudHarvestAgent/jobs.py
@@ -210,9 +210,18 @@ class JobQueue:
         return self
 
     def add_task_chain_from_dict(self, task_chain_id: str, task_chain_model: dict) -> BaseTaskChain:
+        from CloudHarvestCorePluginManager import Registry
+        task_structure = Registry.find(result_key='cls', name=task_chain_model['name'], category=task_chain_model['category'])
+
+        if task_structure:
+            task_structure = task_structure[0]
+
+        else:
+            raise ValueError(f'{task_chain_id}: Task model `{task_chain_model["category"]}/{task_chain_model["name"]}` not found in the Registry.')
+
         # Create a task chain from the template from the dictionary
         from CloudHarvestCoreTasks.factories import task_chain_from_dict
-        task_chain = task_chain_from_dict(template=task_chain_model['model'], **task_chain_model['config'])
+        task_chain = task_chain_from_dict(template=task_structure, **task_chain_model['config'])
 
         # Override the BaseTaskChain's id with the task's id
         task_chain.id = task_chain_id
@@ -410,7 +419,6 @@ def get_oldest_task_from_queue(client: StrictRedis,
                 id (str) a UUID for the task
                 name (str) the name of the task
                 category (str) the category of the task
-                model (dict) a dictionary representing a TaskChain
                 config (dict) a dictionary of configuration parameters provided by the user or application
                 created (datetime) the time the task was created
             }

--- a/CloudHarvestAgent/jobs.py
+++ b/CloudHarvestAgent/jobs.py
@@ -211,7 +211,9 @@ class JobQueue:
 
     def add_task_chain_from_dict(self, task_chain_id: str, task_chain_model: dict) -> BaseTaskChain:
         from CloudHarvestCorePluginManager import Registry
-        task_structure = Registry.find(result_key='cls', name=task_chain_model['name'], category=task_chain_model['category'])
+        from copy import deepcopy
+        # We deepcopy the template so that the copy in the Registry is not modified
+        task_structure = deepcopy(Registry.find(result_key='cls', name=task_chain_model['name'], category=task_chain_model['category']))
 
         if task_structure:
             task_structure = task_structure[0]

--- a/CloudHarvestAgent/templates/reports/harvest/agent-nodes.yaml
+++ b/CloudHarvestAgent/templates/reports/harvest/agent-nodes.yaml
@@ -1,0 +1,56 @@
+report:
+  description: Generates a list of all Agents
+  headers:
+    - Platform
+    - Service
+    - Type
+    - Account
+    - Region
+    - Name
+    - Ip
+    - Port
+    - Version
+    - Os
+    - Python
+    - Duration
+    - AvailableChains
+    - AvailableTasks
+    - AvailableTemplates
+    - Start
+    - Last
+
+  tasks:
+    - redis:
+        name: Retrieve information on Agents
+        result_as: harvest_nodes
+        silo: harvest-nodes
+        command: get
+        arguments:
+          patterns: "agent*"
+        serialization: true
+
+    - dataset:
+        name: Format the data
+        data: var.harvest_nodes
+        filters: '.*'
+        stages:
+          - convert_list_to_string:
+                source_key: available_chains
+
+          - convert_list_to_string:
+              source_key: available_tasks
+
+          - convert_list_to_string:
+              source_key: available_templates
+
+          - rename_keys:  # Rename the PSTAR keys to match the headers
+              mapping:
+                "pstar_platform": "platform"
+                "pstar_service": "service"
+                "pstar_type": "type"
+                "pstar_account": "account"
+                "pstar_region": "region"
+
+          - title_keys:
+              remove_characters:
+                - "_"

--- a/CloudHarvestAgent/templates/reports/harvest/agent-nodes.yaml
+++ b/CloudHarvestAgent/templates/reports/harvest/agent-nodes.yaml
@@ -1,11 +1,7 @@
 report:
   description: Generates a list of all Agents
   headers:
-    - Platform
-    - Service
-    - Type
-    - Account
-    - Region
+    - Accounts
     - Name
     - Ip
     - Port
@@ -35,6 +31,9 @@ report:
         filters: '.*'
         stages:
           - convert_list_to_string:
+              source_key: accounts
+
+          - convert_list_to_string:
                 source_key: available_chains
 
           - convert_list_to_string:
@@ -42,14 +41,6 @@ report:
 
           - convert_list_to_string:
               source_key: available_templates
-
-          - rename_keys:  # Rename the PSTAR keys to match the headers
-              mapping:
-                "pstar_platform": "platform"
-                "pstar_service": "service"
-                "pstar_type": "type"
-                "pstar_account": "account"
-                "pstar_region": "region"
 
           - title_keys:
               remove_characters:

--- a/CloudHarvestAgent/templates/reports/harvest/api-nodes.yaml
+++ b/CloudHarvestAgent/templates/reports/harvest/api-nodes.yaml
@@ -1,0 +1,40 @@
+report:
+  description: Generates a list of all Agent and API nodes
+  headers:
+    - Role
+    - Name
+    - Ip
+    - Port
+    - Version
+    - Os
+    - Python
+    - Duration
+    - AvailableChains
+    - AvailableTasks
+    - Start
+    - Last
+
+  tasks:
+    - redis:
+        name: Retrieve information on Agent and API nodes
+        result_as: harvest_nodes
+        silo: harvest-nodes
+        command: get
+        arguments:
+          patterns: "api*"
+        serialization: true
+
+    - dataset:
+        name: Format the data
+        data: var.harvest_nodes
+        filters: '.*'
+        stages:
+          - convert_list_to_string:
+                source_key: available_chains
+
+          - convert_list_to_string:
+              source_key: available_tasks
+
+          - title_keys:
+              remove_characters:
+                - "_"

--- a/CloudHarvestAgent/templates/reports/harvest/api-nodes.yaml
+++ b/CloudHarvestAgent/templates/reports/harvest/api-nodes.yaml
@@ -9,8 +9,6 @@ report:
     - Os
     - Python
     - Duration
-    - AvailableChains
-    - AvailableTasks
     - Start
     - Last
 

--- a/CloudHarvestAgent/templates/reports/harvest/jobs.yaml
+++ b/CloudHarvestAgent/templates/reports/harvest/jobs.yaml
@@ -1,0 +1,111 @@
+report:
+  description: Displays the data collection jobs and their status.
+  headers:
+    - Id
+    - Stage
+    - Name
+    - Description
+    - Status
+    - Records
+    - Duration
+    - Start
+    - End
+
+  tasks:
+    # Data retrieval tasks
+    - redis:
+        name: Get Enqueued tasks
+        description: Displays the status of the tasks that are currently awaiting processing.
+        result_as: harvest_task_queue
+        silo: harvest-task-queue
+        command: get
+        arguments:
+          patterns: "task::*"
+        serialization: true
+
+    - redis:
+        name: Get Active tasks
+        description: Displays the status of the tasks that are currently being processed.
+        result_as: harvest_tasks
+        silo: harvest-tasks
+        command: get
+        arguments:
+          patterns: "task::*"
+        serialization: true
+
+    - redis:
+        name: Get Completed tasks
+        description: Displays the status of the tasks that have been completed.
+        result_as: harvest_task_results
+        silo: harvest-task-results
+        command: get
+        arguments:
+          patterns: "*"
+          keys: "meta"
+        serialization: true
+
+    # Data formatting tasks
+    - dataset:
+        name: Modify enqueued task data
+        description: Formats the data from the enqueued tasks.
+        data: var.harvest_task_queue
+        result_as: harvest_task_queue
+        stages:
+          - add_keys:
+              keys: Stage
+              default_value:  enqueued
+          - splice_key:
+              source_key: _id
+              start: 6        # 'task::' is 6 characters long
+
+    - dataset:
+        name: Modify processing task data
+        description: Formats the data from the processing tasks.
+        data: var.harvest_tasks
+        result_as: harvest_tasks
+        stages:
+          - add_keys:
+              keys: Stage
+              default_value:  processing
+          - splice_key:
+              source_key: _id
+              start: 6
+          - unnest_records:
+              key_pattern: "meta.*"
+              nest_level: 1
+
+    - dataset:
+        name: Modify completed task data
+        description: Formats the data from the completed tasks.
+        data: var.harvest_task_results
+        result_as: harvest_task_results
+        stages:
+          - add_keys:
+              keys: Stage
+              default_value:  completed
+          - unwind:
+              source_key: meta
+          - unnest_records:
+              key_pattern: "meta.*"
+              nest_level: 1
+          - match_and_remove:
+              matching_expressions:
+                - 'Position==Total'
+
+    - dataset:
+        name: Consolidate data
+        description: Combines the data from the enqueued, active, and completed tasks.
+        filters: '.*'
+        result_as: harvest_jobs
+        stages:
+          - add_records:
+              records:
+                - var.harvest_task_queue
+                - var.harvest_tasks
+                - var.harvest_task_results
+          - rename_keys:
+              mapping:
+                _id: Id
+          - title_keys:
+              remove_characters:
+                - "_"

--- a/CloudHarvestAgent/templates/reports/harvest/jobs.yaml
+++ b/CloudHarvestAgent/templates/reports/harvest/jobs.yaml
@@ -1,15 +1,18 @@
 report:
+  name: Harvest Jobs
   description: Displays the data collection jobs and their status.
   headers:
+    - Start
+    - End
     - Id
     - Stage
     - Name
-    - Description
-    - Status
-    - Records
     - Duration
-    - Start
-    - End
+    - Status
+    - Errors
+    - Records
+    - Bytes
+    - Description
 
   tasks:
     # Data retrieval tasks
@@ -41,7 +44,10 @@ report:
         command: get
         arguments:
           patterns: "*"
-          keys: "meta"
+          keys:
+            - template
+            - metrics
+            - errors
         serialization: true
 
     # Data formatting tasks
@@ -70,9 +76,8 @@ report:
           - splice_key:
               source_key: _id
               start: 6
-          - unnest_records:
-              key_pattern: "meta.*"
-              nest_level: 1
+          - nest_keys:
+              source_keys: meta
 
     - dataset:
         name: Modify completed task data
@@ -84,13 +89,24 @@ report:
               keys: Stage
               default_value:  completed
           - unwind:
-              source_key: meta
-          - unnest_records:
-              key_pattern: "meta.*"
-              nest_level: 1
+              source_key: metrics
           - match_and_remove:
               matching_expressions:
-                - 'Position==Total'
+                - 'metrics.Position==Total'
+          - rename_keys:
+              mapping:
+                template.name: Name
+                template.description: Description
+                metrics.Position: Position
+                metrics.Status: Status
+                metrics.Records: Records
+                metrics.DataBytes: Bytes
+                metrics.Duration: Duration
+                metrics.Start: Start
+                metrics.End: End
+          - count_elements:
+              source_key: errors
+              target_key: Errors
 
     - dataset:
         name: Consolidate data

--- a/CloudHarvestAgent/templates/reports/harvest/meta.yaml
+++ b/CloudHarvestAgent/templates/reports/harvest/meta.yaml
@@ -1,0 +1,34 @@
+report:
+  description: |
+    This report returns information from the `meta` collection where all objects across all platforms is stored. The meta
+    collection is used to find an object based on its platform, collection, collection id.
+  headers:
+    - Active
+    - Platform
+    - Service
+    - Type
+    - Account
+    - Region
+    - Collection
+    - CollectionId
+    - LastSeen
+
+  tasks:
+    - mongo:
+        name: get meta collection
+        result_as: result
+        collection: meta
+        filters: '*'
+
+        pipeline:
+          - $project:
+              Active: "$Harvest.Active"
+              Platform: "$Harvest.Platform"
+              Service: "$Harvest.Service"
+              Type: "$Harvest.Type"
+              Account: "$Harvest.Account"
+              Region: "$Harvest.Region"
+              Collection: 1
+              CollectionId: 1
+              UniqueFilter: "$Harvest.Module.FilterCriteria"
+              LastSeen: "$Harvest.Dates.LastSeen"

--- a/CloudHarvestAgent/templates/reports/harvest/pstar.yaml
+++ b/CloudHarvestAgent/templates/reports/harvest/pstar.yaml
@@ -1,0 +1,35 @@
+report:
+  description: |
+    This report returns Platform/Service/Type/Account/Region (PSTAR) data associated with data collection jobs where
+    Platform = the cloud provider (AWS, Azure, Google Cloud)
+    Service = the cloud provide service (EC2, RDS, Route53)
+    Type = the service subtype (Instance, Cluster, Record)
+    Region = the geographic location of the object (us-east-1, ap-southeast-2)
+  
+  headers:
+    - Platform
+    - Service
+    - Type
+    - Account
+    - Region
+    - Count
+    - StartTime
+    - EndTime
+    - Errors
+  
+  tasks:
+    - mongo:
+        collection: pstar
+        filters: '.*'
+
+        pipeline: 
+          "$project": 
+            Platform: 1,
+            Service: 1,
+            Type: 1,
+            Account: 1,
+            Region: 1,
+            Count: 1,
+            StartTime: 1,
+            EndTime: 1,
+            Errors: 1

--- a/CloudHarvestAgent/templates/reports/harvest/templates.yaml
+++ b/CloudHarvestAgent/templates/reports/harvest/templates.yaml
@@ -27,9 +27,19 @@ report:
           - split_key_to_keys:
               source_key: available_templates
               target_keys:
-                - Type
+                - type_concat
                 - Template
               separator: "/"
+          - split_key_to_keys:
+              source_key: type_concat
+              target_keys:
+                - word_template
+                - Type
+              separator: "_"
+          - drop_keys:
+                keys:
+                  - type_concat
+                  - word_template
           - sort_records:
               keys:
                 - Type

--- a/CloudHarvestAgent/templates/reports/harvest/templates.yaml
+++ b/CloudHarvestAgent/templates/reports/harvest/templates.yaml
@@ -1,0 +1,36 @@
+report:
+  headers:
+    - Type
+    - Template
+
+  tasks:
+    - redis:
+        name: Retrieve information on Agents
+        result_as: harvest_nodes
+        silo: harvest-nodes
+        command: get
+        arguments:
+          patterns: "agent*"
+        serialization: true
+
+    - dataset:
+        name: Format the data
+        data: var.harvest_nodes
+        filters: '.*'
+        stages:
+          - set_keys:
+              keys:
+                - available_templates
+          - unwind:
+              source_key: available_templates
+          - remove_duplicate_records:
+          - split_key_to_keys:
+              source_key: available_templates
+              target_keys:
+                - Type
+                - Template
+              separator: "/"
+          - sort_records:
+              keys:
+                - Type
+                - Template

--- a/harvest.yaml
+++ b/harvest.yaml
@@ -101,3 +101,10 @@ api:
 
   # API token for authentication
   # token: api-token-here
+
+########################################################################################################################
+# Plugin Configuration
+########################################################################################################################
+#plugins:
+#  - branch: "0.2.0"
+#    url_or_package_name: "https://github.com/Cloud-Harvest/CloudHarvestPluginAws.git"

--- a/harvest.yaml
+++ b/harvest.yaml
@@ -30,19 +30,6 @@ agent:
     # The interval in seconds at which the agent will report metrics to the API.
     reporting_interval_seconds: 1
 
-  # PSTAR - Platform, Service, Type, Account, Region
-  # Determines the PSTAR this agent is associated with. This is used to determine which TaskChains are allowed to
-  # run on this agent. By default, all TaskChains are allowed to run on an agent; however, in larger deployments, you
-  # may want to restrict the TaskChains that can run on a given agent, providing dedicated or isolated agents.
-  pstar:
-    # Each key's value is a regex expression. If TaskChain contains a PSTAR and the expression matches, it will be
-    # allowed to run on this agent.
-#    platform: '*'
-#    service: '*'
-#    type: '*'
-#    account: '*'
-#    region: '*'
-
   # TaskChains and Queue Management
   tasks:
 
@@ -101,6 +88,21 @@ api:
 
   # API token for authentication
   # token: api-token-here
+
+########################################################################################################################
+# Platform Configuration
+# Tells the Agent which platforms and accounts which are available to it. The agent will only run TaskChains that are
+# compatible with the designated platforms and accounts.
+########################################################################################################################
+platforms:
+  aws:              # The platform name.
+    accounts:       # The list of AWS accounts that this agent can access.
+      - 123456789
+      - 987654321
+      - 111111111
+      - 222222222
+    role_name: harvest   # The role to assume when running tasks on this platform. This is applied to the role ARN when
+                         # assuming the role. The role must be defined in the AWS account, such as: arn:aws:iam::123456789:role/harvest
 
 ########################################################################################################################
 # Plugin Configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-CloudHarvestCoreTasks @ git+https://github.com/Cloud-Harvest/CloudHarvestCoreTasks.git@0.6.2
+CloudHarvestCoreTasks @ git+https://github.com/Cloud-Harvest/CloudHarvestCoreTasks.git@0.6.3
 Flask
 PyYAML
 flatten-json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-CloudHarvestCorePluginManager @ git+https://github.com/Cloud-Harvest/CloudHarvestCorePluginManager.git@0.4.0
-CloudHarvestCoreTasks @ git+https://github.com/Cloud-Harvest/CloudHarvestCoreTasks.git@0.6.0
+CloudHarvestCoreTasks @ git+https://github.com/Cloud-Harvest/CloudHarvestCoreTasks.git@0.6.2
 Flask
 PyYAML
 flatten-json


### PR DESCRIPTION
- Changes supporting CloudHarvestCoreTasks 0.6.3
- The `available_templates` information is now included in the heartbeat
- Added `agent/list_plugins` and `agent/install_plugins` endpoints
- Replaced `pstar` with `accounts` key in heartbeat
- Added `harvest.templates` report
- Updated some templates
